### PR TITLE
ci: auto bump patch version on master push

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,36 @@
+name: Auto Version Bump
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  bump-version:
+    # Skip if this push was made by the bot itself
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version
+        run: npm version patch --no-git-tag-version
+
+      - name: Read new version
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        run: |
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically bumps the patch version in `package.json` on every push to master
- Uses `npm version patch --no-git-tag-version` to increment, then commits and pushes the change back
- Dual infinite-loop prevention: `github.actor` check skips the job when the bot pushes, and `[skip ci]` in the commit message prevents workflow re-trigger

## Test plan
- [ ] Merge to master and verify the action runs
- [ ] Confirm `package.json` version increments (e.g., `0.2.0` → `0.2.1`)
- [ ] Confirm the bump commit does NOT trigger a second run (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)