### PR TITLE
refactor: extract shared/state.ts for generic JSON state persistence

### DIFF
--- a/shared/state.test.ts
+++ b/shared/state.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadState, saveState } from './state.ts';
+
+interface TestState {
+	version: number;
+	updatedAt: string;
+	data: string;
+}
+
+describe('loadState', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'pai-state-test-'));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('returns null when file does not exist', () => {
+		const result = loadState<TestState>(join(tempDir, 'missing.json'));
+		expect(result).toBeNull();
+	});
+
+	test('returns null for invalid JSON', () => {
+		const path = join(tempDir, 'bad.json');
+		Bun.write(path, 'not-json');
+		const result = loadState<TestState>(path);
+		expect(result).toBeNull();
+	});
+
+	test('returns parsed object for valid JSON file', () => {
+		const path = join(tempDir, 'state.json');
+		const data: TestState = { version: 1, updatedAt: '2024-01-01T00:00:00.000Z', data: 'hello' };
+		Bun.write(path, JSON.stringify(data));
+		const result = loadState<TestState>(path);
+		expect(result).toEqual(data);
+	});
+});
+
+describe('saveState', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'pai-state-test-'));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('writes state as pretty-printed JSON', () => {
+		const path = join(tempDir, 'state.json');
+		const state: TestState = { version: 1, updatedAt: '', data: 'test' };
+		saveState(state, path);
+		expect(existsSync(path)).toBe(true);
+		const raw = readFileSync(path, 'utf-8');
+		expect(raw).toContain('\n');
+		const parsed = JSON.parse(raw);
+		expect(parsed.version).toBe(1);
+		expect(parsed.data).toBe('test');
+	});
+
+	test('stamps updatedAt with current timestamp', () => {
+		const path = join(tempDir, 'state.json');
+		const before = Date.now();
+		const state: TestState = { version: 1, updatedAt: '', data: 'ts-test' };
+		saveState(state, path);
+		const after = Date.now();
+
+		const parsed = JSON.parse(readFileSync(path, 'utf-8')) as TestState;
+		const savedTs = new Date(parsed.updatedAt).getTime();
+		expect(savedTs).toBeGreaterThanOrEqual(before);
+		expect(savedTs).toBeLessThanOrEqual(after);
+	});
+
+	test('mutates state.updatedAt in place', () => {
+		const path = join(tempDir, 'state.json');
+		const state: TestState = { version: 1, updatedAt: 'old', data: 'mutate' };
+		saveState(state, path);
+		expect(state.updatedAt).not.toBe('old');
+	});
+
+	test('roundtrip: save then load returns equivalent state', () => {
+		const path = join(tempDir, 'state.json');
+		const state: TestState = { version: 2, updatedAt: '', data: 'roundtrip' };
+		saveState(state, path);
+		const loaded = loadState<TestState>(path);
+		expect(loaded?.version).toBe(2);
+		expect(loaded?.data).toBe('roundtrip');
+		expect(loaded?.updatedAt).toBe(state.updatedAt);
+	});
+});

--- a/shared/state.ts
+++ b/shared/state.ts
@@ -1,0 +1,28 @@
+/**
+ * Generic JSON state persistence for .pait/ tool state files.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Load a JSON state file from disk.
+ * Returns the parsed object, or null if the file is missing or unreadable.
+ */
+export function loadState<T>(path: string): T | null {
+	try {
+		const content = readFileSync(path, 'utf-8');
+		if (!content) return null;
+		return JSON.parse(content) as T;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Save a state object to disk as pretty-printed JSON.
+ * Stamps `updatedAt` with the current ISO timestamp before writing.
+ */
+export function saveState<T extends { updatedAt: string }>(state: T, path: string): void {
+	state.updatedAt = new Date().toISOString();
+	writeFileSync(path, JSON.stringify(state, null, 2));
+}

--- a/tools/finalize/index.ts
+++ b/tools/finalize/index.ts
@@ -12,6 +12,7 @@ import { log } from '../../shared/log.ts';
 import { promptLine } from '../../shared/prompt.ts';
 import { runClaude } from '../../shared/claude.ts';
 import { findRepoRoot, loadToolConfig, getStateFilePath } from '../../shared/config.ts';
+import { loadState, saveState } from '../../shared/state.ts';
 import { runVerify } from '../verify/index.ts';
 import type { VerifyCommand, E2EConfig } from '../verify/types.ts';
 import type {
@@ -58,18 +59,11 @@ export function parseFinalizeFlags(args: string[]): FinalizeFlags {
 // ---------------------------------------------------------------------------
 
 export function loadFinalizeState(stateFile: string): FinalizeState | null {
-	try {
-		const content = readFileSync(stateFile, 'utf-8');
-		if (!content) return null;
-		return JSON.parse(content);
-	} catch {
-		return null;
-	}
+	return loadState<FinalizeState>(stateFile);
 }
 
 export function saveFinalizeState(state: FinalizeState, stateFile: string): void {
-	state.updatedAt = new Date().toISOString();
-	writeFileSync(stateFile, JSON.stringify(state, null, 2));
+	saveState(state, stateFile);
 }
 
 export function initFinalizeState(): FinalizeState {

--- a/tools/orchestrator/index.ts
+++ b/tools/orchestrator/index.ts
@@ -7,12 +7,13 @@
  */
 
 import { $ } from 'bun';
-import { readFileSync, writeFileSync, unlinkSync, existsSync, rmSync } from 'node:fs';
+import { unlinkSync, existsSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { log, Spinner } from '../../shared/log.ts';
 import { runClaude } from '../../shared/claude.ts';
 import { RunLogger } from '../../shared/logging.ts';
 import { findRepoRoot, loadToolConfig, saveToolConfig, getStateFilePath, migrateStateIfNeeded } from '../../shared/config.ts';
+import { loadState, saveState } from '../../shared/state.ts';
 import { ORCHESTRATOR_DEFAULTS } from './defaults.ts';
 import { runVerify, promptForVerifyCommands } from '../verify/index.ts';
 import type {
@@ -69,20 +70,7 @@ export function parseFlags(args: string[]): OrchestratorFlags {
 // State management
 // ---------------------------------------------------------------------------
 
-export function loadState(stateFile: string): OrchestratorState | null {
-	try {
-		const content = readFileSync(stateFile, 'utf-8');
-		if (!content) return null;
-		return JSON.parse(content);
-	} catch {
-		return null;
-	}
-}
-
-export function saveState(state: OrchestratorState, stateFile: string): void {
-	state.updatedAt = new Date().toISOString();
-	writeFileSync(stateFile, JSON.stringify(state, null, 2));
-}
+export { loadState, saveState } from '../../shared/state.ts';
 
 export function initState(): OrchestratorState {
 	return {


### PR DESCRIPTION
## Summary

Closes #29

## Changes

See issue #29 for full specification.

## Verification

- [x] `bun test` passes


---
Automated by pai orchestrate