### PR TITLE
refactor: split finalize tests into focused test files

### DIFF
--- a/tools/finalize/finalize.git.test.ts
+++ b/tools/finalize/finalize.git.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { $ } from 'bun';
+import { rebaseBranch, detectConflicts } from './index.ts';
+
+describe('git operations', () => {
+	let tempDir: string;
+	let repoRoot: string;
+
+	beforeEach(async () => {
+		tempDir = mkdtempSync(join(tmpdir(), 'pai-finalize-git-'));
+		repoRoot = join(tempDir, 'repo');
+		mkdirSync(repoRoot);
+
+		// Initialize a real git repo with an initial commit
+		await $`git -C ${repoRoot} init`.quiet();
+		await $`git -C ${repoRoot} checkout -b main`.quiet();
+		writeFileSync(join(repoRoot, 'README.md'), 'initial\n');
+		await $`git -C ${repoRoot} add README.md`.quiet();
+		await $`git -C ${repoRoot} commit -m "initial"`.quiet();
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('rebaseBranch: clean rebase succeeds', async () => {
+		// Create a feature branch with a commit
+		await $`git -C ${repoRoot} checkout -b feat/1-test`.quiet();
+		writeFileSync(join(repoRoot, 'feature.txt'), 'feature\n');
+		await $`git -C ${repoRoot} add feature.txt`.quiet();
+		await $`git -C ${repoRoot} commit -m "add feature"`.quiet();
+
+		// Add a non-conflicting commit to main
+		await $`git -C ${repoRoot} checkout main`.quiet();
+		writeFileSync(join(repoRoot, 'other.txt'), 'other\n');
+		await $`git -C ${repoRoot} add other.txt`.quiet();
+		await $`git -C ${repoRoot} commit -m "add other"`.quiet();
+
+		// Rebase feature onto main
+		const result = await rebaseBranch('feat/1-test', 'main', repoRoot);
+		expect(result.ok).toBe(true);
+		expect(result.conflicts).toBeUndefined();
+
+		// Feature branch should now have both commits
+		const logOutput = await $`git -C ${repoRoot} log --oneline`.text();
+		expect(logOutput).toContain('add feature');
+		expect(logOutput).toContain('add other');
+	});
+
+	test('rebaseBranch: conflict detected', async () => {
+		// Create a feature branch that modifies README
+		await $`git -C ${repoRoot} checkout -b feat/2-conflict`.quiet();
+		writeFileSync(join(repoRoot, 'README.md'), 'feature version\n');
+		await $`git -C ${repoRoot} add README.md`.quiet();
+		await $`git -C ${repoRoot} commit -m "feature change"`.quiet();
+
+		// Add a conflicting commit to main
+		await $`git -C ${repoRoot} checkout main`.quiet();
+		writeFileSync(join(repoRoot, 'README.md'), 'main version\n');
+		await $`git -C ${repoRoot} add README.md`.quiet();
+		await $`git -C ${repoRoot} commit -m "main change"`.quiet();
+
+		// Rebase should detect conflict
+		const result = await rebaseBranch('feat/2-conflict', 'main', repoRoot);
+		expect(result.ok).toBe(false);
+		expect(result.conflicts).toBeDefined();
+		expect(result.conflicts!.length).toBeGreaterThan(0);
+		expect(result.conflicts![0].file).toBe('README.md');
+	});
+
+	test('rebaseBranch: no-op when branch already up-to-date', async () => {
+		// Feature branch created from current main tip — no divergence
+		await $`git -C ${repoRoot} checkout -b feat/3-uptodate`.quiet();
+		writeFileSync(join(repoRoot, 'feature.txt'), 'feature\n');
+		await $`git -C ${repoRoot} add feature.txt`.quiet();
+		await $`git -C ${repoRoot} commit -m "add feature"`.quiet();
+
+		const result = await rebaseBranch('feat/3-uptodate', 'main', repoRoot);
+		expect(result.ok).toBe(true);
+		expect(result.conflicts).toBeUndefined();
+	});
+
+	test('detectConflicts: returns empty when no conflicts', async () => {
+		const conflicts = await detectConflicts(repoRoot);
+		expect(conflicts).toEqual([]);
+	});
+});

--- a/tools/finalize/finalize.test.ts
+++ b/tools/finalize/finalize.test.ts
@@ -1,15 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { $ } from 'bun';
 import {
 	parseFinalizeFlags,
 	loadFinalizeState,
 	saveFinalizeState,
-	initFinalizeState,
-	rebaseBranch,
-	detectConflicts
+	initFinalizeState
 } from './index.ts';
 import { determineMergeOrder } from '../../shared/github.ts';
 import type { MergeOrder, FinalizeState } from './types.ts';
@@ -173,89 +170,5 @@ describe('finalize state management', () => {
 
 		expect(loaded!.prs[10].status).toBe('merged');
 		expect(loaded!.prs[10].error).toBeNull();
-	});
-});
-
-describe('git operations', () => {
-	let tempDir: string;
-	let repoRoot: string;
-
-	beforeEach(async () => {
-		tempDir = mkdtempSync(join(tmpdir(), 'pai-finalize-git-'));
-		repoRoot = join(tempDir, 'repo');
-		mkdirSync(repoRoot);
-
-		// Initialize a real git repo with an initial commit
-		await $`git -C ${repoRoot} init`.quiet();
-		await $`git -C ${repoRoot} checkout -b main`.quiet();
-		writeFileSync(join(repoRoot, 'README.md'), 'initial\n');
-		await $`git -C ${repoRoot} add README.md`.quiet();
-		await $`git -C ${repoRoot} commit -m "initial"`.quiet();
-	});
-
-	afterEach(() => {
-		rmSync(tempDir, { recursive: true, force: true });
-	});
-
-	test('rebaseBranch: clean rebase succeeds', async () => {
-		// Create a feature branch with a commit
-		await $`git -C ${repoRoot} checkout -b feat/1-test`.quiet();
-		writeFileSync(join(repoRoot, 'feature.txt'), 'feature\n');
-		await $`git -C ${repoRoot} add feature.txt`.quiet();
-		await $`git -C ${repoRoot} commit -m "add feature"`.quiet();
-
-		// Add a non-conflicting commit to main
-		await $`git -C ${repoRoot} checkout main`.quiet();
-		writeFileSync(join(repoRoot, 'other.txt'), 'other\n');
-		await $`git -C ${repoRoot} add other.txt`.quiet();
-		await $`git -C ${repoRoot} commit -m "add other"`.quiet();
-
-		// Rebase feature onto main
-		const result = await rebaseBranch('feat/1-test', 'main', repoRoot);
-		expect(result.ok).toBe(true);
-		expect(result.conflicts).toBeUndefined();
-
-		// Feature branch should now have both commits
-		const logOutput = await $`git -C ${repoRoot} log --oneline`.text();
-		expect(logOutput).toContain('add feature');
-		expect(logOutput).toContain('add other');
-	});
-
-	test('rebaseBranch: conflict detected', async () => {
-		// Create a feature branch that modifies README
-		await $`git -C ${repoRoot} checkout -b feat/2-conflict`.quiet();
-		writeFileSync(join(repoRoot, 'README.md'), 'feature version\n');
-		await $`git -C ${repoRoot} add README.md`.quiet();
-		await $`git -C ${repoRoot} commit -m "feature change"`.quiet();
-
-		// Add a conflicting commit to main
-		await $`git -C ${repoRoot} checkout main`.quiet();
-		writeFileSync(join(repoRoot, 'README.md'), 'main version\n');
-		await $`git -C ${repoRoot} add README.md`.quiet();
-		await $`git -C ${repoRoot} commit -m "main change"`.quiet();
-
-		// Rebase should detect conflict
-		const result = await rebaseBranch('feat/2-conflict', 'main', repoRoot);
-		expect(result.ok).toBe(false);
-		expect(result.conflicts).toBeDefined();
-		expect(result.conflicts!.length).toBeGreaterThan(0);
-		expect(result.conflicts![0].file).toBe('README.md');
-	});
-
-	test('rebaseBranch: no-op when branch already up-to-date', async () => {
-		// Feature branch created from current main tip — no divergence
-		await $`git -C ${repoRoot} checkout -b feat/3-uptodate`.quiet();
-		writeFileSync(join(repoRoot, 'feature.txt'), 'feature\n');
-		await $`git -C ${repoRoot} add feature.txt`.quiet();
-		await $`git -C ${repoRoot} commit -m "add feature"`.quiet();
-
-		const result = await rebaseBranch('feat/3-uptodate', 'main', repoRoot);
-		expect(result.ok).toBe(true);
-		expect(result.conflicts).toBeUndefined();
-	});
-
-	test('detectConflicts: returns empty when no conflicts', async () => {
-		const conflicts = await detectConflicts(repoRoot);
-		expect(conflicts).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #36

## Changes

See issue #36 for full specification.

## Verification

- [x] `bun test` passes


---
Automated by pai orchestrate